### PR TITLE
Add Debian installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,16 @@ bind : [mod + shift + 5] : moveto_ws5
 yay -S sxwm
 ```
 
+### Debian
+
+```sh
+sudo apt install libx11-dev libxinerama-dev git gcc make
+git clone --depth=1 https://github.com/uint23/sxwm.git
+cd sxwm/
+make
+sudo make clean install
+```
+
 ### Build from Source
 
 ```sh


### PR DESCRIPTION
As Debian is a very popular distribution, I think it is warranted to create installation instructions. I have yet to create a package for Debian, so currently you must compile from source. What I have added here is the (somewhat confusing) package names.