### PR TITLE
Add XSession desktop entry for sxwm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ OBJ_DIR := build
 SRC     := $(wildcard $(SRC_DIR)/*.c)
 OBJ     := $(patsubst $(SRC_DIR)/%.c,$(OBJ_DIR)/%.o,$(SRC))
 
+XSESSIONS := $(DESTDIR)$(PREFIX)/share/xsessions
+
 all: $(BIN)
 
 $(BIN): $(OBJ)
@@ -27,11 +29,16 @@ install: all
 	@echo "Installing $(BIN) to $(DESTDIR)$(PREFIX)/bin..."
 	@mkdir -p $(DESTDIR)$(PREFIX)/bin
 	@install -m 755 $(BIN) $(DESTDIR)$(PREFIX)/bin/$(BIN)
+	@echo "Installing sxwm.desktop to $(XSESSIONS)..."
+	@mkdir -p $(XSESSIONS)
+	@install -m 644 sxwm.desktop $(XSESSIONS)/sxwm.desktop
 	@echo "Installation complete."
 
 uninstall:
 	@echo "Uninstalling $(BIN) from $(DESTDIR)$(PREFIX)/bin..."
 	@rm -f $(DESTDIR)$(PREFIX)/bin/$(BIN)
+	@echo "Uninstalling sxwm.desktop from $(XSESSIONS)..."
+	@rm -f $(XSESSIONS)/sxwm.desktop
 	@echo "Uninstallation complete."
 
 .PHONY: all clean install uninstall

--- a/sxwm.desktop
+++ b/sxwm.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Encoding=UTF-8
+Name=Sxwm
+Comment=Simple Xorg Window Manager
+Exec=sxwm
+Type=XSession


### PR DESCRIPTION
XSession desktop files are used by display managers to suggest desktop environments and window managers to use when a user logs in. This PR adds a `.desktop` entry for sxwm and tweaks the Makefile to include it in the installation process.