### PR TITLE
Remove flickering when changing between workspaces

### DIFF
--- a/src/sxwm.c
+++ b/src/sxwm.c
@@ -203,6 +203,8 @@ void change_workspace(int ws)
 		return;
 	}
 
+	XGrabServer(dpy);
+
 	for (Client *c = workspaces[current_ws]; c; c = c->next) {
 		XUnmapWindow(dpy, c->win);
 	}
@@ -221,6 +223,8 @@ void change_workspace(int ws)
 	long cd = current_ws;
 	XChangeProperty(dpy, root, XInternAtom(dpy, "_NET_CURRENT_DESKTOP", False), XA_CARDINAL, 32, PropModeReplace,
 	                (unsigned char *)&cd, 1);
+
+	XUngrabServer(dpy);
 }
 
 int clean_mask(int mask)


### PR DESCRIPTION
I noticed that windows briefly pop in and out of view when switching between workspaces. The issue is mostly cosmetic but still quite annoying. After some research, I found that it's possible to "grab" the server to suspend the immediate execution of commands, and then "ungrab" it to execute the queued commands almost instantaneously. This results in snappier feedback when changing workspaces. It also appears that DWM uses this approach to address the issue.
