### PR TITLE
Floating window toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The file uses a `key : value` format. Lines starting with `#` are ignored.
 | `resize_master_amount`  | Integer | `1`       | Percentage (%) to increase/decrease the master width when resizing.         |
 | `snap_distance`         | Integer | `5`       | Pixels from screen edge before a floating window snaps to the edge.         |
 | `motion_throttle`       | Integer | `60`      | Target updates per second for mouse drag operations (move/resize/swap). Set close to your monitor's refresh rate for smoother visuals. |
+| `should_float`         | String  | `""`      | A window to always flaot (eg. `st`). For multiple windows, add multiple options.|
 
 ### Keybindings
 

--- a/src/defs.h
+++ b/src/defs.h
@@ -87,6 +87,7 @@ typedef struct {
 	int snap_distance;
 	int bindsn;
 	Binding binds[256];
+	char *should_float[256];
 } Config;
 
 typedef struct {

--- a/src/parser.c
+++ b/src/parser.c
@@ -169,6 +169,12 @@ found:
 
 	char line[512];
 	int lineno = 0;
+	int should_floatn = 0;
+
+	for (int i = 0; i < 256; i++) {
+		cfg->should_float[i] = NULL;
+	}
+
 	while (fgets(line, sizeof line, f)) {
 		lineno++;
 		char *s = strip(line);
@@ -220,6 +226,25 @@ found:
 		}
 		else if (!strcmp(key, "snap_distance")) {
 			cfg->snap_distance = atoi(rest);
+		}
+		else if (!strcmp(key, "should_float")) {
+			// should_float: <window>
+			
+			if (should_floatn >= 256) {
+				fprintf(stderr, "sxwmrc:%d: too many should_float entries\n", lineno);
+				continue;
+			}
+
+			char *win = strip(rest);
+
+			cfg->should_float[should_floatn] = malloc(strlen(win) + 1);
+			if (!cfg->should_float[should_floatn]) {
+				fprintf(stderr, "sxwmrc:%d: out of memory\n", lineno);
+				break;
+			}
+
+			strcpy(cfg->should_float[should_floatn], win);
+			should_floatn++;
 		}
 		else if (!strcmp(key, "call") || !strcmp(key, "bind")) {
 			char *mid = strchr(rest, ':');


### PR DESCRIPTION
Add the `should_float` configuration option. when used as demonstrated below, the selected window will launch floating. it can be toggled much like any other window. fixes #20 .
```
# example usage
should_float : firefox
```