### PR TITLE
Multiple should_float entries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ install: all
 	@echo "Installing man page to $(DESTDIR)$(MAN_DIR)..."
 	@mkdir -p $(DESTDIR)$(MAN_DIR)
 	@install -m 644 $(MAN) $(DESTDIR)$(MAN_DIR)/
+	@echo "Copying default configuration to $(DESTDIR)$(PREFIX)/share/sxwmrc..."
+	@mkdir -p "$(DESTDIR)$(PREFIX)/share"
+	@install -m 644 default_sxrc "$(DESTDIR)$(PREFIX)/share/sxwmrc"
 	@echo "Installation complete."
 
 uninstall:

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The file uses a `key : value` format. Lines starting with `#` are ignored.
 | `resize_master_amount`   | Integer | `1`       | Percent to increase/decrease master width.                                  |
 | `snap_distance`          | Integer | `5`       | Distance (px) before a floating window snaps to edge.                       |
 | `motion_throttle`        | Integer | `60`      | Target FPS for mouse drag actions.                                          |
-| `should_float`           | String  | `st`      | Always-float rule (can list multiple).                                      |
+| `should_float`           | String  | `"st"`    | Always-float rule. Multiple entries should be comma-seperated. Optionally, entries can be enclosed in quotes.|
 
 ---
 

--- a/src/defs.h
+++ b/src/defs.h
@@ -87,7 +87,7 @@ typedef struct {
 	int snap_distance;
 	int bindsn;
 	Binding binds[256];
-	char *should_float[256];
+	char **should_float[256];
 } Config;
 
 typedef struct {

--- a/src/parser.c
+++ b/src/parser.c
@@ -228,7 +228,7 @@ found:
 			cfg->snap_distance = atoi(rest);
 		}
 		else if (!strcmp(key, "should_float")) {
-			// should_float: <window>
+			// should_float: binary --arg,binary2 parameter --arg,binary3
 			
 			if (should_floatn >= 256) {
 				fprintf(stderr, "sxwmrc:%d: too many should_float entries\n", lineno);
@@ -237,13 +237,31 @@ found:
 
 			char *win = strip(rest);
 
-			cfg->should_float[should_floatn] = malloc(strlen(win) + 1);
-			if (!cfg->should_float[should_floatn]) {
-				fprintf(stderr, "sxwmrc:%d: out of memory\n", lineno);
-				break;
+			int count = 0;
+			for (char *p = win; *p; p++) {
+				if (*p == ',') {
+					count++;
+				}
+			}
+			
+			cfg->should_float[should_floatn] = malloc((count + 2) * sizeof(char *));
+
+			// split by commas
+			char *comma = strtok(win, ",");
+
+			int i = 0;
+
+			while (comma) {
+				if (should_floatn < 256) {
+					cfg->should_float[should_floatn][i] = strdup(comma);
+					i++;
+				} else {
+					fprintf(stderr, "sxwmrc:%d: too many should_float entries\n", lineno);
+					break;
+				}
+				comma = strtok(NULL, ",");
 			}
 
-			strcpy(cfg->should_float[should_floatn], win);
 			should_floatn++;
 		}
 		else if (!strcmp(key, "call") || !strcmp(key, "bind")) {

--- a/src/sxwm.c
+++ b/src/sxwm.c
@@ -591,8 +591,15 @@ void hdl_keypress(XEvent *xev)
 			switch (b->type) {
 				case TYPE_CMD:
 					spawn(b->action.cmd);
-					for (int j = 0; j < 256; j++) {
-						if (user_config.should_float[j] && !strcmp(user_config.should_float[j], b->action.cmd[0])) {
+					for (int j = 0; j < 256; j++) {						
+						Bool valid = False;
+						for (int k = 0; user_config.should_float[j] && user_config.should_float[j][k] && b->action.cmd[k]; k++) {
+							if (!strcmp(b->action.cmd[k], user_config.should_float[j][k])) {
+								valid = True;
+								break;
+							}
+						}
+						if (valid) {
 							next_should_float = True;
 							break;
 						}


### PR DESCRIPTION
Multiple entries are now supported on a single `should_float` entry, as discussed in #22. Entries should be enclosed with quotes (though for backwards compatibility this is optional) and separated by commas, as shown below.
```
should_float : "firefox","st --arg"
```
Examples have been added to `README.md`.