### PR TITLE
Copy sxwmrc during installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ install: all
 	@echo "Installing man page to $(DESTDIR)$(MAN_DIR)..."
 	@mkdir -p $(DESTDIR)$(MAN_DIR)
 	@install -m 644 $(MAN) $(DESTDIR)$(MAN_DIR)/
+	@echo "Copying default configuration to $(DESTDIR)$(PREFIX)/share/sxwmrc..."
+	@mkdir -p "$(DESTDIR)$(PREFIX)/share"
+	@install -m 644 default_sxrc "$(DESTDIR)$(PREFIX)/share/sxwmrc"
 	@echo "Installation complete."
 
 uninstall:

--- a/src/parser.c
+++ b/src/parser.c
@@ -160,6 +160,11 @@ int parser(Config *cfg)
         goto found;
     }
 
+	snprintf(path, sizeof path, "/usr/local/share/sxwmrc");
+	if (access(path, R_OK) == 0) {
+		goto found;
+	}
+
 found:
     FILE *f = fopen(path, "r");
     if (!f) {


### PR DESCRIPTION
During installation, copy `default_sxrc` to `/usr/local/share/sxwmrc`. Also make the parser scan this path (with lowest priority) when looking for the rc file. Fixes #28.

Might it be a good idea to add a `-c/--config` flag so that configs can be loaded from other locations, as the `Makefile` already supports different prefixes?