### PR TITLE
Added NixOS installation instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,19 @@ sudo zypper install libX11-devel libXinerama-devel gcc make</code></pre>
 yay -S sxwm
 ```
 
+### NixOS
+
+Temporarily install with nix-shell
+```sh
+nix-shell -p sxwm
+```
+or add `sxwm` to your configuration.nix packages.
+
+To enable this package as a window manager in your system, add this line to your configuration.nix
+```
+services.xserver.windowManager.sxwm.enable = true;
+```
+
 ### Build from Source
 
 ```sh


### PR DESCRIPTION
I packaged `sxwm` to the official [nixpkgs source repository](https://github.com/NixOS/nixpkgs/) and opened a pull request there. So I added a section of this `README.md` with installation instructions for NixOS.

I'll let you know when the pull request is merged to the official NixOS source and then you can merge this one, but I'm opening this now just to let you know how things are.

I also plan on integrating custom configuration in the NixOS build of this package in the future, so that people can use their own sxwm configs in NixOS with sxwm base code. When I do that I think it could be useful to make a seperate `NixOS-guide.md` specifically to guide that part, so that the `README.md` isn't too cluttered with it. But it would still be a short file.

Let me know what you think of this and feel free to change what you feel is best!