### PR TITLE
Add FreeBSD installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,13 @@ sudo nixos-rebuild switch
 slackpkg install gcc make libX11 libXinerama</code></pre>
 </details>
 
+<details>
+<summary>FreeBSD</summary>
+<pre><code># If you use doas or su instead of sudo, modify the following commands accordingly.
+sudo pkg update
+sudo pkg install gcc gmake libX11 libXinerama</code></pre>
+</details>
+
 ---
 
 ## Build & Install
@@ -241,6 +248,7 @@ yay -S sxwm
 ```sh
 git clone --depth=1 https://github.com/uint23/sxwm.git
 cd sxwm/
+# Replace make with gmake on FreeBSD
 make
 sudo make clean install
 ```


### PR DESCRIPTION
This PR adds FreeBSD installation instructions as it's probably a good thing to have. I have also tested to make sure the project works on FreeBSD and it does.

I considered just leaving the privilege escalation step empty but for consistency I used `sudo`, as it's available on FreeBSD (FreeBSD does not install a privilege escalation program by default), and the `doas` package info has information about it being a `sudo` "alternative", indicating `sudo` is the default assumption.

Nevertheless, I have added a comment about the need to replace `sudo` if you use something else, as this is fairly common on FreeBSD.

I have also added a comment about needing to replace `make` with `gmake` in the compilation step as `make` refers to BSD Make on FreeBSD, whereas this program (I assume) is designed for GNU Make, which is `gmake` on FreeBSD.