### PR TITLE
Add missing dependency to ubuntu install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ bind : mod + shift + 5 : moveto_ws5
 <details>
 <summary>Debian / Ubuntu / Linux Mint</summary>
 <pre><code>sudo apt update
-sudo apt install libx11-dev libxinerama-dev build-essential</code></pre>
+sudo apt install libx11-dev libxcursor-dev libxinerama-dev build-essential</code></pre>
 </details>
 
 <details>


### PR DESCRIPTION
Without this, I'm getting a fatal error when running `make`. Afterwards it succeeded. Tested on debian

src/sxwm.c:33:10 `#include <X11/Xcursor/Xcursor.h>` No such file or directory.