### PR TITLE
add exec config file keyword

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -5,7 +5,5 @@ CompileFlags:
     "-Wall",
     "-Wextra",
     "-O3",
-    "-Isrc",
-    "-lX11",
-    "-lXinerama"
+    "-Isrc"
   ]

--- a/src/defs.h
+++ b/src/defs.h
@@ -92,6 +92,7 @@ typedef struct {
 	Bool new_win_focus;
 	Binding binds[256];
 	char **should_float[256];
+    char *torun[256];
 } Config;
 
 typedef struct {

--- a/src/sxwm.c
+++ b/src/sxwm.c
@@ -1144,6 +1144,33 @@ void reload_config(void)
 		fprintf(stderr, "sxrc: error parsing config file\n");
 		init_defaults();
 	}
+    
+    for (int i = 0; i < 256; i++) {
+        if (user_config.torun[i]) {
+            printf("[DEBUG] executing %s\n", user_config.torun[i]);
+            pid_t pid = fork();
+			if (pid == 0) {
+				char *argv[256];
+				int j = 0;
+				char *arg = strtok(user_config.torun[i], " ");
+				while (arg && j < 256) {
+					argv[j++] = arg;
+					arg = strtok(NULL, " ");
+				}
+				argv[j] = NULL;
+				execvp(argv[0], argv);
+				perror("execvp");
+				_exit(127);
+			}
+			else if (pid > 0) {
+				// parent: don’t wait, just continue (background)
+			}
+			else {
+				perror("fork");
+			} 
+        }
+    }
+
 	grab_keys();
 	XUngrabButton(dpy, AnyButton, AnyModifier, root);
 	XGrabButton(dpy, Button1, user_config.modkey, root, True, ButtonPressMask | ButtonReleaseMask | PointerMotionMask,
@@ -1251,6 +1278,32 @@ void setup(void)
 		fprintf(stderr, "sxrc: error parsing config file\n");
 		init_defaults();
 	}
+    
+    for (int i = 0; i < 256; i++) {
+        if (user_config.torun[i]) {
+            printf("[DEBUG] executing %s\n", user_config.torun[i]);
+            pid_t pid = fork();
+			if (pid == 0) {
+				char *argv[256];
+				int j = 0;
+				char *arg = strtok(user_config.torun[i], " ");
+				while (arg && j < 256) {
+					argv[j++] = arg;
+					arg = strtok(NULL, " ");
+				}
+				argv[j] = NULL;
+				execvp(argv[0], argv);
+				perror("execvp");
+				_exit(127);
+			}
+			else if (pid > 0) {
+				// parent: don’t wait, just continue (background)
+			}
+			else {
+				perror("fork");
+			} 
+        }
+    }
 	grab_keys();
 
 	c_normal = XcursorLibraryLoadCursor(dpy, "left_ptr");

--- a/src/sxwm.c
+++ b/src/sxwm.c
@@ -1144,33 +1144,6 @@ void reload_config(void)
 		fprintf(stderr, "sxrc: error parsing config file\n");
 		init_defaults();
 	}
-    
-    for (int i = 0; i < 256; i++) {
-        if (user_config.torun[i]) {
-            printf("[DEBUG] executing %s\n", user_config.torun[i]);
-            pid_t pid = fork();
-			if (pid == 0) {
-				char *argv[256];
-				int j = 0;
-				char *arg = strtok(user_config.torun[i], " ");
-				while (arg && j < 256) {
-					argv[j++] = arg;
-					arg = strtok(NULL, " ");
-				}
-				argv[j] = NULL;
-				execvp(argv[0], argv);
-				perror("execvp");
-				_exit(127);
-			}
-			else if (pid > 0) {
-				// parent: don’t wait, just continue (background)
-			}
-			else {
-				perror("fork");
-			} 
-        }
-    }
-
 	grab_keys();
 	XUngrabButton(dpy, AnyButton, AnyModifier, root);
 	XGrabButton(dpy, Button1, user_config.modkey, root, True, ButtonPressMask | ButtonReleaseMask | PointerMotionMask,
@@ -1302,8 +1275,8 @@ void setup(void)
 			else {
 				perror("fork");
 			} 
-        }
-    }
+        	}
+    	}
 	grab_keys();
 
 	c_normal = XcursorLibraryLoadCursor(dpy, "left_ptr");


### PR DESCRIPTION
This PR adds a new key to the config file, `exec`. Its parsing is much the same as `should_float`, in that values should be comma seperated and optionally can be wrapped in quotes. 