### PR TITLE
Refactor keybinding configuration and parsing logic

### DIFF
--- a/src/defs.h
+++ b/src/defs.h
@@ -50,6 +50,8 @@
 	"8"					"\0"\
 	"9"					"\0"
 
+#define MAX_BINDS 256
+
 typedef enum { DRAG_NONE, DRAG_MOVE, DRAG_RESIZE, DRAG_SWAP } DragMode;
 typedef void (*EventHandler)(XEvent *);
 
@@ -118,6 +120,11 @@ typedef struct {
 	Client *client;
 	Bool enabled;
 } Scratchpad;
+
+typedef struct {
+	const char *name;
+	void (*fn)(void);
+} CommandEntry;
 
 extern void centre_window();
 extern void close_focused(void);


### PR DESCRIPTION
- Added MAX_BINDS macro to replace magic number (256) in alloc_bind
- Fixed potential null dereference in strip() on empty strings
- Corrected redundant KeySym assignment in parse_combo()
- Improved clarity and maintainability of call_table and helper functions
- Ensured safe string handling with proper bounds and terminators
- Added fallback logic for unknown key symbols using parse_keysym()
- Proper bounds checks on buffers and allocations