### PR TITLE
Setting and resetting opacity based on window fullscreen state

### DIFF
--- a/src/sxwm.c
+++ b/src/sxwm.c
@@ -2630,6 +2630,22 @@ void toggle_floating_global(void)
 	update_borders();
 }
 
+void set_opacity(Window w, double opacity)
+{
+    unsigned long op = (unsigned long)(opacity * 0xFFFFFFFF);
+    Atom atom = XInternAtom(dpy, "_NET_WM_WINDOW_OPACITY", False);
+
+    if (opacity < 0.0) opacity = 0.0;
+    if (opacity > 1.0) opacity = 1.0;
+    XChangeProperty(dpy, w, atom, XA_CARDINAL, 32, PropModeReplace, (unsigned char *)&op, 1);
+}
+
+void reset_opacity(Window w)
+{
+	Atom atom = XInternAtom(dpy, "_NET_WM_WINDOW_OPACITY", False);
+	XDeleteProperty(dpy, w, atom);
+}
+
 void toggle_fullscreen(void)
 {
 	if (!focused) {
@@ -2659,10 +2675,12 @@ void toggle_fullscreen(void)
 		XSetWindowBorderWidth(dpy, focused->win, 0);
 		XMoveResizeWindow(dpy, focused->win, fs_x, fs_y, fs_w, fs_h);
 		XRaiseWindow(dpy, focused->win);
+		set_opacity(focused->win, 100);
 	}
 	else {
 		XMoveResizeWindow(dpy, focused->win, focused->orig_x, focused->orig_y, focused->orig_w, focused->orig_h);
 		XSetWindowBorderWidth(dpy, focused->win, user_config.border_width);
+		reset_opacity(focused->win);
 
 		if (!focused->floating) {
 			focused->mon = get_monitor_for(focused);

--- a/src/sxwm.c
+++ b/src/sxwm.c
@@ -2176,29 +2176,6 @@ void set_win_scratchpad(int n)
 	scratchpads[n].enabled = False;
 }
 
-Bool window_should_float(Window w)
-{
-	XClassHint ch;
-	if (XGetClassHint(dpy, w, &ch)) {
-		for (int i = 0; i < 256; i++) {
-			if (!user_config.should_float[i] || !user_config.should_float[i][0]) {
-				break;
-			}
-
-			if ((ch.res_class && !strcmp(ch.res_class, user_config.should_float[i][0])) ||
-			    (ch.res_name && !strcmp(ch.res_name, user_config.should_float[i][0]))) {
-				XFree(ch.res_class);
-				XFree(ch.res_name);
-				return True;
-			}
-		}
-		XFree(ch.res_class);
-		XFree(ch.res_name);
-	}
-
-	return False;
-}
-
 void reset_opacity(Window w)
 {
 	Atom atom = XInternAtom(dpy, "_NET_WM_WINDOW_OPACITY", False);


### PR DESCRIPTION
When using picom, windows are set to opacity based on your config.
You can force them to be set to a specific opacity using _NET_WM_WINDOW_OPACITY.
To let picom take back control, you can simply remove the property from the window.

This code adds two functions: `set_opacity` taking a `Window` and a `double` as arguments, and `reset_opacity` which takes a `Window`. 