### PR TITLE
Fixed compilation errors on non-Linux systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
-CC     = cc
-CFLAGS = -std=c99 -Wall -Wextra -O3 -Isrc
-LDFLAGS = -lX11 -lXinerama -lXcursor
+CONFIG ?= config.mk
+include $(CONFIG)
 
-PREFIX  = /usr/local
 BIN     = sxwm
 SRC_DIR = src
 OBJ_DIR = build
@@ -11,46 +9,3 @@ SRC = $(shell find $(SRC_DIR) -type f -name '*.c')
 OBJ = $(SRC:$(SRC_DIR)/%.c=$(OBJ_DIR)/%.o)
 
 MAN     = sxwm.1
-MAN_DIR = $(PREFIX)/share/man/man1
-XSESSIONS = $(DESTDIR)$(PREFIX)/share/xsessions
-
-all: $(BIN)
-
-$(BIN): $(OBJ)
-	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
-
-$(OBJ_DIR)/%.o: $(SRC_DIR)/%.c | $(OBJ_DIR)
-	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS) -c -o $@ $<
-
-$(OBJ_DIR):
-	@mkdir -p $@
-
-clean:
-	@rm -rf $(OBJ_DIR) $(BIN)
-
-install: all
-	@echo "Installing $(BIN) to $(DESTDIR)$(PREFIX)/bin..."
-	@mkdir -p "$(DESTDIR)$(PREFIX)/bin"
-	@install -m 755 $(BIN) "$(DESTDIR)$(PREFIX)/bin/$(BIN)"
-	@echo "Installing sxwm.desktop to $(XSESSIONS)..."
-	@mkdir -p "$(XSESSIONS)"
-	@install -m 644 sxwm.desktop "$(XSESSIONS)/sxwm.desktop"
-	@echo "Installing man page to $(DESTDIR)$(MAN_DIR)..."
-	@mkdir -p $(DESTDIR)$(MAN_DIR)
-	@install -m 644 $(MAN) $(DESTDIR)$(MAN_DIR)/
-	@echo "Copying default configuration to $(DESTDIR)$(PREFIX)/share/sxwmrc..."
-	@mkdir -p "$(DESTDIR)$(PREFIX)/share"
-	@install -m 644 default_sxwmrc "$(DESTDIR)$(PREFIX)/share/sxwmrc"
-	@echo "Installation complete."
-
-uninstall:
-	@echo "Uninstalling $(BIN) from $(DESTDIR)$(PREFIX)/bin..."
-	@rm -f "$(DESTDIR)$(PREFIX)/bin/$(BIN)"
-	@echo "Uninstalling sxwm.desktop from $(XSESSIONS)..."
-	@rm -f "$(XSESSIONS)/sxwm.desktop"
-	@echo "Uninstalling man page from $(DESTDIR)$(MAN_DIR)..."
-	@rm -f $(DESTDIR)$(MAN_DIR)/$(MAN)
-	@echo "Uninstallation complete."
-
-.PHONY: all clean install uninstall

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,45 @@
 include config.mk
 
-BIN     = sxwm
-SRC_DIR = src
-OBJ_DIR = build
-
 SRC = $(shell find $(SRC_DIR) -type f -name '*.c')
 OBJ = $(SRC:$(SRC_DIR)/%.c=$(OBJ_DIR)/%.o)
 
-MAN     = sxwm.1
+all: $(BIN)
+
+$(BIN): $(OBJ)
+	$(CC) $(CFLAGS) -o $@ $(OBJ) $(LDFLAGS)
+
+$(OBJ_DIR)/%.o: $(SRC_DIR)/%.c | $(OBJ_DIR)
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+$(OBJ_DIR):
+	@mkdir -p $@
+
+clean:
+	@rm -rf $(OBJ_DIR) $(BIN)
+
+install: all
+	@echo "Installing $(BIN) to $(DESTDIR)$(PREFIX)/bin..."
+	@mkdir -p "$(DESTDIR)$(PREFIX)/bin"
+	@install -m 755 $(BIN) "$(DESTDIR)$(PREFIX)/bin/$(BIN)"
+	@echo "Installing sxwm.desktop to $(XSESSIONS)..."
+	@mkdir -p "$(XSESSIONS)"
+	@install -m 644 sxwm.desktop "$(XSESSIONS)/sxwm.desktop"
+	@echo "Installing man page to $(DESTDIR)$(MAN_DIR)..."
+	@mkdir -p $(DESTDIR)$(MAN_DIR)
+	@install -m 644 $(MAN) $(DESTDIR)$(MAN_DIR)/
+	@echo "Copying default configuration to $(DESTDIR)$(PREFIX)/share/sxwmrc..."
+	@mkdir -p "$(DESTDIR)$(PREFIX)/share"
+	@install -m 644 default_sxwmrc "$(DESTDIR)$(PREFIX)/share/sxwmrc"
+	@echo "Installation complete."
+
+uninstall:
+	@echo "Uninstalling $(BIN) from $(DESTDIR)$(PREFIX)/bin..."
+	@rm -f "$(DESTDIR)$(PREFIX)/bin/$(BIN)"
+	@echo "Uninstalling sxwm.desktop from $(XSESSIONS)..."
+	@rm -f "$(XSESSIONS)/sxwm.desktop"
+	@echo "Uninstalling man page from $(DESTDIR)$(MAN_DIR)..."
+	@rm -f $(DESTDIR)$(MAN_DIR)/$(MAN)
+	@echo "Uninstallation complete."
+
+.PHONY: all clean install uninstall

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,18 @@
-CC      ?= gcc
-CFLAGS  ?= -std=c99 -Wall -Wextra -O3 -Isrc
-LDFLAGS ?= -lX11 -lXinerama -lXcursor
+CC     = cc
+CFLAGS = -std=c99 -Wall -Wextra -O3 -Isrc
+LDFLAGS = -lX11 -lXinerama -lXcursor
 
-PREFIX  ?= /usr/local
-BIN     := sxwm
-SRC_DIR := src
-OBJ_DIR := build
-SRC     := $(wildcard $(SRC_DIR)/*.c)
-OBJ     := $(patsubst $(SRC_DIR)/%.c,$(OBJ_DIR)/%.o,$(SRC))
-DEP     := $(OBJ:.o=.d)
+PREFIX  = /usr/local
+BIN     = sxwm
+SRC_DIR = src
+OBJ_DIR = build
 
-MAN     := sxwm.1
-MAN_DIR := $(PREFIX)/share/man/man1
+SRC = $(shell find $(SRC_DIR) -type f -name '*.c')
+OBJ = $(SRC:$(SRC_DIR)/%.c=$(OBJ_DIR)/%.o)
 
-XSESSIONS := $(DESTDIR)$(PREFIX)/share/xsessions
+MAN     = sxwm.1
+MAN_DIR = $(PREFIX)/share/man/man1
+XSESSIONS = $(DESTDIR)$(PREFIX)/share/xsessions
 
 all: $(BIN)
 
@@ -22,9 +21,7 @@ $(BIN): $(OBJ)
 
 $(OBJ_DIR)/%.o: $(SRC_DIR)/%.c | $(OBJ_DIR)
 	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS) -MMD -MP -c -o $@ $<
-
--include $(DEP)
+	$(CC) $(CFLAGS) -c -o $@ $<
 
 $(OBJ_DIR):
 	@mkdir -p $@

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-CONFIG ?= config.mk
-include $(CONFIG)
+include config.mk
 
 BIN     = sxwm
 SRC_DIR = src

--- a/mkconfig/config.mk.linux
+++ b/mkconfig/config.mk.linux
@@ -1,7 +1,12 @@
 CC     = cc
-CFLAGS = -I/usr/X11R6/include -Wall -Wextra -O3 -Isrc
-LDFLAGS = -L/usr/X11R6/lib -lX11 -lXinerama -lXcursor
+CFLAGS = -std=c99 -Wall -Wextra -O3 -Isrc
+LDFLAGS = -lX11 -lXinerama -lXcursor
 
 PREFIX  = /usr/local
+BIN     = sxwm
+SRC_DIR = src
+OBJ_DIR = build
+
+MAN     = sxwm.1
 MAN_DIR = $(PREFIX)/share/man/man1
 XSESSIONS = $(DESTDIR)$(PREFIX)/share/xsessions

--- a/mkconfig/config.mk.linux
+++ b/mkconfig/config.mk.linux
@@ -1,0 +1,7 @@
+CC     = cc
+CFLAGS = -I/usr/X11R6/include -Wall -Wextra -O3 -Isrc
+LDFLAGS = -L/usr/X11R6/lib -lX11 -lXinerama -lXcursor
+
+PREFIX  = /usr/local
+MAN_DIR = $(PREFIX)/share/man/man1
+XSESSIONS = $(DESTDIR)$(PREFIX)/share/xsessions

--- a/mkconfig/config.mk.openbsd
+++ b/mkconfig/config.mk.openbsd
@@ -3,5 +3,10 @@ CFLAGS = -I/usr/X11R6/include -Wall -Wextra -O3 -Isrc
 LDFLAGS = -L/usr/X11R6/lib -lX11 -lXinerama -lXcursor
 
 PREFIX  = /usr/local
+BIN     = sxwm
+SRC_DIR = src
+OBJ_DIR = build
+
+MAN     = sxwm.1
 MAN_DIR = $(PREFIX)/share/man/man1
 XSESSIONS = $(DESTDIR)$(PREFIX)/share/xsessions

--- a/mkconfig/config.mk.openbsd
+++ b/mkconfig/config.mk.openbsd
@@ -1,5 +1,5 @@
 CC     = cc
-CFLAGS = -I/usr/X11R6/include -Wall -Wextra -O3 -Isrc
+CFLAGS = -std=c99 -I/usr/X11R6/include -Wall -Wextra -O3 -Isrc
 LDFLAGS = -L/usr/X11R6/lib -lX11 -lXinerama -lXcursor
 
 PREFIX  = /usr/local

--- a/mkconfig/config.mk.openbsd
+++ b/mkconfig/config.mk.openbsd
@@ -1,0 +1,7 @@
+CC     = cc
+CFLAGS = -I/usr/X11R6/include -Wall -Wextra -O3 -Isrc
+LDFLAGS = -L/usr/X11R6/lib -lX11 -lXinerama -lXcursor
+
+PREFIX  = /usr/local
+MAN_DIR = $(PREFIX)/share/man/man1
+XSESSIONS = $(DESTDIR)$(PREFIX)/share/xsessions

--- a/src/parser.c
+++ b/src/parser.c
@@ -1,6 +1,6 @@
 #define _POSIX_C_SOURCE 200809L
 #include <ctype.h>
-#include <linux/limits.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/sxwm.c
+++ b/src/sxwm.c
@@ -17,7 +17,7 @@
 #include <X11/X.h>
 #include <err.h>
 #include <stdio.h>
-#include <linux/limits.h>
+#include <limits.h>
 #include <signal.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Compiling on OpenBSD causes an [error](https://files.catbox.moe/7qxrx9.webp) when compiling because sxwm.c and parser.c have this `#include <linux/limits.h>` line as shown. 

This patch fixes it by replacing `#include <linux/limits.h>` with `#include <limits.h>` in both sxwm.c and parser.c