### PR TITLE
add mirror layout option

### DIFF
--- a/patches/option-mirror-layout.patch
+++ b/patches/option-mirror-layout.patch
@@ -1,0 +1,116 @@
+Author: palsmo
+Date: 2025-08-14
+Description: Add mirror layout option
+Commit Version: 6cbfafb ([1] refactoring)
+
+Add 'mirror_layout' configuration option to !flip master-stack layout.
+When enabled, master window appears on the right side instead of left,
+and resize controls are reversed to maintain intuitive behavior.
+
+---
+
+diff --git a/src/defs.h b/src/defs.h
+index 63cf4a0..bc9d861 100644
+--- a/src/defs.h
++++ b/src/defs.h
+@@ -103,6 +103,7 @@ typedef struct {
+ 	Bool new_win_focus;
+ 	Bool warp_cursor;
+ 	Bool new_win_master;
++	Bool mirror_layout;
+ 	Binding binds[MAX_ITEMS];
+ 	char **should_float[MAX_ITEMS];
+ 	char **start_fullscreen[MAX_ITEMS];
+diff --git a/src/parser.c b/src/parser.c
+index f0cc0d5..2904a6e 100644
+--- a/src/parser.c
++++ b/src/parser.c
+@@ -492,6 +492,9 @@ found:
+ 		else if (!strcmp(key, "new_win_master")) {
+ 			cfg->new_win_master = !strcmp(rest, "true") ? True : False;
+ 		}
++		else if (!strcmp(key, "mirror_layout")) {
++			cfg->mirror_layout = !strcmp(rest, "true") ? True : False;
++		}
+ 		else if (!strcmp(key, "open_in_workspace")) {
+ 			char *mid = strchr(rest, ':');
+ 			if (!mid) {
+diff --git a/src/sxwm.c b/src/sxwm.c
+index ab73c71..dfda2a7 100644
+--- a/src/sxwm.c
++++ b/src/sxwm.c
+@@ -1389,6 +1389,7 @@ void init_defaults(void)
+ 	default_config.new_win_focus = True;
+ 	default_config.warp_cursor = True;
+ 	default_config.new_win_master = False;
++	default_config.mirror_layout = False;
+ 
+ 	if (backup_binds) {
+ 		for (unsigned long i = 0; i < LENGTH(binds); i++) {
+@@ -1821,8 +1822,15 @@ void resize_master_add(void)
+ 	int m = focused ? focused->mon : 0;
+ 	float *mw = &user_config.master_width[m];
+ 
+-	if (*mw < MF_MAX - 0.001f) {
+-		*mw += ((float)user_config.resize_master_amt / 100);
++	if (user_config.mirror_layout) {
++		if (*mw < MF_MAX + 0.001f) {
++			*mw -= ((float)user_config.resize_master_amt / 100);
++		}
++	}
++	else {
++		if (*mw < MF_MAX - 0.001f) {
++			*mw += ((float)user_config.resize_master_amt / 100);
++		}
+ 	}
+ 	tile();
+ 	update_borders();
+@@ -1834,8 +1842,15 @@ void resize_master_sub(void)
+ 	int m = focused ? focused->mon : 0;
+ 	float *mw = &user_config.master_width[m];
+ 
+-	if (*mw > MF_MIN + 0.001f) {
+-		*mw -= ((float)user_config.resize_master_amt / 100);
++	if (user_config.mirror_layout) {
++		if (*mw > MF_MIN - 0.001f) {
++			*mw += ((float)user_config.resize_master_amt / 100);
++		}
++	}
++	else {
++		if (*mw > MF_MIN + 0.001f) {
++			*mw -= ((float)user_config.resize_master_amt / 100);
++		}
+ 	}
+ 	tile();
+ 	update_borders();
+@@ -2311,10 +2326,20 @@ void tile(void)
+ 		int master_w = (N > 1) ? (int)(tile_w * mf) : tile_w;
+ 		int stack_w = (N > 1) ? (tile_w - master_w - gx) : 0;
+ 
++		int master_x, stack_x;
++		if (user_config.mirror_layout) {
++			master_x = tile_x + stack_w + (N > 1 ? gx : 0);
++			stack_x = tile_x;
++		}
++		else {
++			master_x = tile_x;
++			stack_x = tile_x + master_w + gx;
++		}
++
+ 		{
+ 			Client *c = stackers[0];
+ 			int bw2 = 2 * user_config.border_width;
+-			XWindowChanges wc = {.x = tile_x,
++			XWindowChanges wc = {.x = master_x,
+ 			                     .y = tile_y,
+ 			                     .width = MAX(1, master_w - bw2),
+ 			                     .height = MAX(1, tile_h - bw2),
+@@ -2406,7 +2431,7 @@ void tile(void)
+ 		int sy = tile_y;
+ 		for (int i = 1; i < N; i++) {
+ 			Client *c = stackers[i];
+-			XWindowChanges wc = {.x = tile_x + master_w + gx,
++			XWindowChanges wc = {.x = stack_x,
+ 			                     .y = sy,
+ 			                     .width = MAX(1, stack_w - (2 * user_config.border_width)),
+ 			                     .height = MAX(1, heights_final[i] - (2 * user_config.border_width)),

--- a/src/defs.h
+++ b/src/defs.h
@@ -103,6 +103,7 @@ typedef struct {
 	Bool new_win_focus;
 	Bool warp_cursor;
 	Bool new_win_master;
+	Bool mirror_layout;
 	Binding binds[MAX_ITEMS];
 	char **should_float[MAX_ITEMS];
 	char **start_fullscreen[MAX_ITEMS];

--- a/src/parser.c
+++ b/src/parser.c
@@ -492,6 +492,9 @@ found:
 		else if (!strcmp(key, "new_win_master")) {
 			cfg->new_win_master = !strcmp(rest, "true") ? True : False;
 		}
+		else if (!strcmp(key, "mirror_layout")) {
+			cfg->mirror_layout = !strcmp(rest, "true") ? True : False;
+		}
 		else if (!strcmp(key, "open_in_workspace")) {
 			char *mid = strchr(rest, ':');
 			if (!mid) {


### PR DESCRIPTION
Add 'mirror_layout' configuration option to !flip master-stack layout.
When enabled, master window appears on the right side instead of left,
and resize controls are reversed to maintain intuitive behavior.