### PR TITLE
Small miscellaneous revisions/refactors

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ sudo emaint -a sync
 <details>
 <summary>Void Linux</summary>
 <pre><code>sudo xbps-install -S
-sudo xbps-install libX11-devel libXinerama-devel gcc make</code></pre>
+sudo xbps-install libX11-devel libXinerama-devel libXcursor-devel gcc make</code></pre>
 </details>
 
 <details>

--- a/src/defs.h
+++ b/src/defs.h
@@ -20,7 +20,7 @@
 #define UDIST(a, b) abs((int)(a) - (int)(b))
 #define CLAMP(x, lo, hi) (((x) < (lo)) ? (lo) : ((x) > (hi)) ? (hi) : (x))
 #define MAX_CLIENTS 99
-#define MAX_SCRATCHPADS 20
+#define MAX_SCRATCHPADS 32
 #define MIN_WINDOW_SIZE 20
 #define MAX_ITEMS 256
 #define BIND(mod, key, cmdstr) {(mod), XK_##key, {cmdstr}, False}
@@ -108,8 +108,13 @@ typedef struct {
 	char **should_float[MAX_ITEMS];
 	char **start_fullscreen[MAX_ITEMS];
 	char **can_swallow[MAX_ITEMS];
+<<<<<<< HEAD
     char **can_be_swallowed[MAX_ITEMS];
 	char **scratchpads[32];
+=======
+	char **can_be_swallowed[MAX_ITEMS];
+	char **scratchpads[MAX_SCRATCHPADS];
+>>>>>>> e770299 (replace random 20 (???) with MAX_SCRATCHPADS)
 	char **open_in_workspace[MAX_ITEMS];
 	char *to_run[MAX_ITEMS];
 } Config;

--- a/src/defs.h
+++ b/src/defs.h
@@ -108,13 +108,8 @@ typedef struct {
 	char **should_float[MAX_ITEMS];
 	char **start_fullscreen[MAX_ITEMS];
 	char **can_swallow[MAX_ITEMS];
-<<<<<<< HEAD
-    char **can_be_swallowed[MAX_ITEMS];
-	char **scratchpads[32];
-=======
 	char **can_be_swallowed[MAX_ITEMS];
 	char **scratchpads[MAX_SCRATCHPADS];
->>>>>>> e770299 (replace random 20 (???) with MAX_SCRATCHPADS)
 	char **open_in_workspace[MAX_ITEMS];
 	char *to_run[MAX_ITEMS];
 } Config;

--- a/src/parser.c
+++ b/src/parser.c
@@ -105,7 +105,7 @@ static unsigned parse_combo(const char *combo, Config *cfg, KeySym *out_ks)
 {
 	unsigned m = 0;
 	KeySym ks = NoSymbol;
-	char buf[256];
+	char buf[MAX_ITEMS];
 
 	strncpy(buf, combo, sizeof(buf) - 1);
 	buf[sizeof(buf) - 1] = '\0';
@@ -195,7 +195,7 @@ found:
 	int to_run = 0;
 
 	/* Initialize should_float matrix */
-	for (int j = 0; j < 256; j++) {
+	for (int j = 0; j < MAX_ITEMS; j++) {
 		cfg->should_float[j] = calloc(2, sizeof(char *));
 		if (!cfg->should_float[j]) {
 			goto cleanup_file;
@@ -268,7 +268,7 @@ found:
 			cfg->snap_distance = atoi(rest);
 		}
 		else if (!strcmp(key, "should_float")) {
-			if (should_floatn >= 256) {
+			if (should_floatn >= MAX_ITEMS) {
 				fprintf(stderr, "sxwmrc:%d: too many should_float entries\n", lineno);
 				continue;
 			}
@@ -287,7 +287,7 @@ found:
 			char *comma = strtok_r(final, ",", &comma_ptr);
 
 			/* store each comma separated value in a seperate row */
-			while (comma && should_floatn < 256) {
+			while (comma && should_floatn < MAX_ITEMS) {
 				comma = strip(comma);
 				if (*comma == '"') {
 					comma++;
@@ -433,7 +433,7 @@ found:
 			}
 		}
 		else if (!strcmp(key, "exec")) {
-			if (to_run >= 256) {
+			if (to_run >= MAX_ITEMS) {
 				fprintf(stderr, "sxwmrc:%d: too many exec commands\n", lineno);
 				continue;
 			}
@@ -461,7 +461,7 @@ found:
 		else if (!strcmp(key, "can_swallow")) {
 			char *token = strtok(rest, ",");
 			int i = 0;
-			while (token && i < 256) {
+			while (token && i < MAX_ITEMS) {
 				char *item = strip_quotes(strip(token));
 				if (*item) {
 					cfg->can_swallow[i] = malloc(2 * sizeof(char *));
@@ -479,7 +479,7 @@ found:
 		else if (!strcmp(key, "can_be_swallowed")) {
 			char *token = strtok(rest, ",");
 			int i = 0;
-			while (token && i < 256) {
+			while (token && i < MAX_ITEMS) {
 				char *item = strip_quotes(strip(token));
 				if (*item) {
 					cfg->can_be_swallowed[i] = malloc(2 * sizeof(char *));
@@ -516,7 +516,7 @@ found:
 
 			/* find free slot in open_in_workspace */
 			int slot = -1;
-			for (int i = 0; i < 256; i++) {
+			for (int i = 0; i < MAX_ITEMS; i++) {
 				if (!cfg->open_in_workspace[i]) {
 					slot = i;
 					break;
@@ -549,7 +549,7 @@ found:
 
 			int start_fullscreen_idx = 0;
 			/* find first empty slot */
-			for (int i = 0; i < 256; i++) {
+			for (int i = 0; i < MAX_ITEMS; i++) {
 				if (!cfg->start_fullscreen[i]) {
 					start_fullscreen_idx = i;
 					break;
@@ -557,7 +557,7 @@ found:
 			}
 
 			/* store each comma separated value in a separate row */
-			while (comma && start_fullscreen_idx < 256) {
+			while (comma && start_fullscreen_idx < MAX_ITEMS) {
 				comma = strip(comma);
 				if (*comma == '"') {
 					comma++;
@@ -600,7 +600,7 @@ cleanup_file:
 	if (f) {
 		fclose(f);
 	}
-	for (int j = 0; j < 256; j++) {
+	for (int j = 0; j < MAX_ITEMS; j++) {
 		if (cfg->should_float[j]) {
 			free(cfg->should_float[j][0]);
 			free(cfg->should_float[j]);

--- a/src/sxwm.c
+++ b/src/sxwm.c
@@ -3023,7 +3023,7 @@ int main(int ac, char **av)
 	if (ac > 1) {
 		if (strcmp(av[1], "-v") == 0 || strcmp(av[1], "--version") == 0) {
 			printf("%s\n%s\n%s\n", SXWM_VERSION, SXWM_AUTHOR, SXWM_LICINFO);
-			exit(0);
+			return 0;
 		}
 		else if (strcmp(av[1], "-b") == 0 || strcmp(av[1], "--backup") == 0) {
 			puts("sxwm: using backup keybinds");
@@ -3033,7 +3033,7 @@ int main(int ac, char **av)
 			puts("usage:\n");
 			puts("\t[-v || --version]: See the version of sxwm\n");
 			puts("\t[-b || --backup]: Use backup set of keybinds with sxwm\n");
-			exit(0);
+			return 0;
 		}
 	}
 	setup();

--- a/src/sxwm.c
+++ b/src/sxwm.c
@@ -2783,10 +2783,10 @@ void update_modifier_masks(void)
 			/* keycode at mod[i][j] */
 			KeyCode keycode = mod_mapping->modifiermap[i * mod_mapping->max_keypermod + j];
 			if (keycode == num) {
-				numlock_mask = (1 << i); /* which mod bit == NumLock key */
+				numlock_mask = (1u << i); /* which mod bit == NumLock key */
 			}
 			if (keycode == mode) {
-				mode_switch_mask = (1 << i); /* which mod bit == Mode_switch key */
+				mode_switch_mask = (1u << i); /* which mod bit == Mode_switch key */
 			}
 		}
 	}

--- a/src/sxwm.c
+++ b/src/sxwm.c
@@ -3023,7 +3023,7 @@ int main(int ac, char **av)
 	if (ac > 1) {
 		if (strcmp(av[1], "-v") == 0 || strcmp(av[1], "--version") == 0) {
 			printf("%s\n%s\n%s\n", SXWM_VERSION, SXWM_AUTHOR, SXWM_LICINFO);
-			return 0;
+			return EXIT_SUCCESS;
 		}
 		else if (strcmp(av[1], "-b") == 0 || strcmp(av[1], "--backup") == 0) {
 			puts("sxwm: using backup keybinds");
@@ -3033,11 +3033,11 @@ int main(int ac, char **av)
 			puts("usage:\n");
 			puts("\t[-v || --version]: See the version of sxwm\n");
 			puts("\t[-b || --backup]: Use backup set of keybinds with sxwm\n");
-			return 0;
+			return EXIT_SUCCESS;
 		}
 	}
 	setup();
 	puts("sxwm: starting...");
 	run();
-	return 0;
+	return EXIT_SUCCESS;
 }

--- a/src/sxwm.c
+++ b/src/sxwm.c
@@ -1106,7 +1106,7 @@ void hdl_map_req(XEvent *xev)
 	}
 
 	if (open_windows == MAX_CLIENTS) {
-		printf("sxwm: max clients reached, ignoring map request\n");
+		fprintf(stderr, "sxwm: max clients reached, ignoring map request\n");
 		return;
 	}
 
@@ -1458,13 +1458,13 @@ Bool is_child_proc(pid_t parent_pid, pid_t child_pid)
 		snprintf(path, sizeof(path), "/proc/%d/stat", current_pid);
 		f = fopen(path, "r");
 		if (!f) {
-			printf("sxwm: could not open %s\n", path);
+			fprintf(stderr, "sxwm: could not open %s\n", path);
 			return False;
 		}
 
 		int ppid = 0;
 		if (fscanf(f, "%*d %*s %*c %d", &ppid) != 1) {
-			printf("sxwm: failed to read ppid from %s\n", path);
+			fprintf(stderr, "sxwm: failed to read ppid from %s\n", path);
 			fclose(f);
 			return False;
 		}
@@ -1476,7 +1476,7 @@ Bool is_child_proc(pid_t parent_pid, pid_t child_pid)
 
 		if (ppid <= 1) {
 			/* Reached init or kernel */
-			printf("sxwm: reached init/kernel, no relationship found\n");
+			fprintf(stderr, "sxwm: reached init/kernel, no relationship found\n");
 			break;
 		}
 		current_pid = ppid;
@@ -1720,7 +1720,7 @@ void quit(void)
 	XFreeCursor(dpy, cursor_move);
 	XFreeCursor(dpy, cursor_normal);
 	XFreeCursor(dpy, cursor_resize);
-	printf("quitting...\n");
+	puts("quitting...");
 	running = False;
 }
 
@@ -3014,7 +3014,7 @@ void xev_case(XEvent *xev)
 		evtable[xev->type](xev);
 	}
 	else {
-		printf("sxwm: invalid event type: %d\n", xev->type);
+		fprintf(stderr, "sxwm: invalid event type: %d\n", xev->type);
 	}
 }
 
@@ -3037,7 +3037,7 @@ int main(int ac, char **av)
 		}
 	}
 	setup();
-	printf("sxwm: starting...\n");
+	puts("sxwm: starting...");
 	run();
 	return 0;
 }


### PR DESCRIPTION
1. use MAX_ITEMS consistently, even in parser.c
2. make printing more consistent (puts when there isnt any formatting, and fprintf to stderr on error)
3. replace the 20 in the Config struct for scratchpads with MAX_SCRATCHPADS to be more consistent
4. use switch for parse_combo (generally just because it's better fit for this type of logic, but it may also improve performance by reducing the needed comparisons)
5. consistently use return instead of exit in main
6. use EXIT_SUCCESS and EXIT_FAILURE, where appropriate, specifically in main() where we return  0 instead of EXIT_SUCCESS