### PR TITLE
Fix Window swallowing to target the parent window and not any swallower

### DIFF
--- a/src/sxwm.c
+++ b/src/sxwm.c
@@ -670,11 +670,11 @@ int get_monitor_for(Client *c)
 
 pid_t get_parent_process(pid_t c)
 {
-	unsigned int v = 0;
+	pid_t v = -1;
 	FILE *f;
 	char buf[256];
 
-	snprintf(buf, sizeof(buf) - 1, "/proc/%u/stat", (unsigned)c);
+	snprintf(buf, sizeof(buf), "/proc/%u/stat", (unsigned)c);
 	if (!(f = fopen(buf, "r"))) {
 		return 0;
 	}


### PR DESCRIPTION
This is a fix to make the swallower window the current parent one.

Currently it will tile the new window to master and then will put the parent back to it's position in the chain when closing the swallowed window. that can be changed to use the swallower position for the swallowed window

I added two functions.
- check_parent -> go through every process until it hits the last parent
- get_parent_process -> get the the parent process of the currently selected process